### PR TITLE
Fixing problems with %check... comments that cause incorrect renderin…

### DIFF
--- a/latest/OnlineTutorial/Lemmas.md
+++ b/latest/OnlineTutorial/Lemmas.md
@@ -29,7 +29,8 @@ for zero in an array. What makes this problem interesting is that the array we a
 searching in has two special properties: all elements are non-negative, and each successive
 element decreases by at most one from the previous element. In code:
 
-```dafny <!-- %check-verify Lemmas.1.expect -->
+<!-- %check-verify Lemmas.1.expect -->
+```dafny
 method FindZero(a: array<int>) returns (index: int)
   requires forall i :: 0 <= i < a.Length ==> 0 <= a[i]
   requires forall i :: 0 < i < a.Length ==> a[i-1]-1 <= a[i]
@@ -43,7 +44,8 @@ Then we know that `6 <= a[j+1]`, `5 <= a[j+2]`, etc. In fact, the next zero can'
 be until 7 more elements in the array. So we don't even have to search for a zero until
 `a[j+a[j]]`. So we could write a loop like:
 
-```dafny <!-- %check-verify Lemmas.2.expect -->
+<!-- %check-verify Lemmas.2.expect -->
+```dafny
 method FindZero(a: array<int>) returns (index: int)
   requires forall i :: 0 <= i < a.Length ==> 0 <= a[i]
   requires forall i :: 0 < i < a.Length ==> a[i-1]-1 <= a[i]
@@ -79,7 +81,8 @@ on the verification of the
 program. You may think of lemmas as heavyweight assertions, in that they are only
 necessary to help the proof of the program along. A typical lemma might look like:
 
-```dafny <!-- %no-check -->
+<!-- %no-check -->
+```dafny
 lemma Lemma(...)
   ensures (desirable property)
 {
@@ -91,7 +94,8 @@ For the zero search problem, the desirable property is that none of the elements
 `index` until `index + a[index]` can be zero. We take the array and the index
 to start from as parameters, with the usual requirements from `FindZero`:
 
-```dafny <!-- %check-verify Lemmas.3.expect -->
+<!-- %check-verify Lemmas.3.expect -->
+```dafny
 lemma SkippingLemma(a: array<int>, j: int)
   requires forall i :: 0 <= i < a.Length ==> 0 <= a[i]
   requires forall i :: 0 < i < a.Length ==> a[i-1]-1 <= a[i]
@@ -109,7 +113,8 @@ then do a crucial step: check that our lemma is sufficient to prove the loop inv
 By making this check before filling in the lemma body, we ensure that we are trying to
 prove the right thing. The `FindZero` method becomes:
 
-```dafny <!-- %check-verify Lemmas.4.expect  -->
+<!-- %check-verify Lemmas.4.expect  -->
+```dafny
 lemma SkippingLemma(a: array<int>, j: int)
   requires forall i :: 0 <= i < a.Length ==> 0 <= a[i]
   requires forall i :: 0 < i < a.Length ==> a[i-1]-1 <= a[i]
@@ -148,7 +153,8 @@ We start with the crucial property of the array, that it only decreases
 slowly. We can ask whether certain properties hold by using assertions. For
 example, we can see that Dafny knows:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 lemma SkippingLemma(a: array<int>, j: int)
   requires forall i :: 0 <= i < a.Length ==> 0 <= a[i]
   requires forall i :: 0 < i < a.Length ==> a[i-1]-1 <= a[i]
@@ -173,7 +179,8 @@ together. We want to iterate from `j` to `j + a[j]`, keeping
 track of the lower bound as we go. We also keep track of the fact that all
 of the elements we have seen so far are not zero:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 lemma SkippingLemma(a: array<int>, j: int)
   requires forall i :: 0 <= i < a.Length ==> 0 <= a[i]
   requires forall i :: 0 < i < a.Length ==> a[i-1]-1 <= a[i]
@@ -232,7 +239,8 @@ To see an example of this, we will consider the problem of counting.
 We will count the number of `true`s in a sequence of
 `bool`s, using the `count` function, given below:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 function count(a: seq<bool>): nat
 {
   if |a| == 0 then 0 else
@@ -253,7 +261,8 @@ to requiring lemmas. There is a desirable property of count that we would like t
 able to use in verifying a program that uses this function: it distributes
 over addition. By this we mean:
 
-```dafny <!-- %no-check -->
+<!-- %no-check -->
+```dafny
 forall a, b :: count(a + b) == count(a) + count(b)
 ```
 
@@ -281,7 +290,8 @@ is more work than proving the concrete, specific case, so we will tackle this ca
 Thus the lemma should take as arguments the sequences of interest, and the postcondition is
 as follows:
 
-```dafny <!-- %check-verify Lemmas.5.expect -->
+<!-- %check-verify Lemmas.5.expect -->
+```dafny
 lemma DistributiveLemma(a: seq<bool>, b: seq<bool>)
   ensures count(a + b) == count(a) + count(b)
 {
@@ -308,7 +318,8 @@ trait of lemmas. We notice that if `a == []`, then `a + b == b`, regardless of w
 `b` is. Lemmas handle cases using the same thing code does to handle cases: if statements. A short
 proof of the desirable property is given using asserts below.
 
-```dafny <!-- %check-verify Lemmas.6.expect -->
+<!-- %check-verify Lemmas.6.expect -->
+```dafny
 lemma DistributiveLemma(a: seq<bool>, b: seq<bool>)
   ensures count(a + b) == count(a) + count(b)
 {
@@ -339,7 +350,8 @@ Our goal is to relate `count(a + b)` to `count(a)` and `count(b)`. If `a`
 is not the empty sequence, then when we employ our trick of following the definition to expand
 `count(a + b)`, we get:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 function count(a: seq<bool>): nat
 {
   if |a| == 0 then 0 else
@@ -356,7 +368,8 @@ method m2(a: seq<bool>, b:seq<bool>)
 Notice that we get `count([a[0]])` and `a[1..]`. These two terms would also appear
 if we expanded `count(a)`. Specifically:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method m2(a: seq<bool>, b:seq<bool>)
   requires |a| > 0
 {
@@ -372,7 +385,8 @@ function count(a: seq<bool>): nat
 Finally, we can substitute this definition for `count(a)` into the postcondition
 to get:
 
-```dafny <!-- %no-check -->
+<!-- %no-check -->
+```dafny
   assert count(a + b) == count(a) + count(b); // postcondition
   assert count(a + b) == count([a[0]]) + count(a[1..]) + count(b);
 ```
@@ -413,7 +427,8 @@ given the relationship between iteration and recursion as two means of achieving
 With this in mind, we can complete the lemma by calling the lemma recursively in the else branch of the
 if statement:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 lemma DistributiveLemma(a: seq<bool>, b: seq<bool>)
   ensures count(a + b) == count(a) + count(b)
 {
@@ -443,7 +458,8 @@ A directed graph is composed
 of a number of `Node`s, each with some links to other `Node`s. These links are single directional,
 and the only restriction on them is that a node cannot link to itself. Nodes are defined as:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 class Node
 {
   // a single field giving the nodes linked to
@@ -454,7 +470,8 @@ class Node
 We represent a graph as a set of Nodes that only point to other nodes in the graph, and not to itself.
 We call such a set of nodes *closed*:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 class Node
 {
   // a single field giving the nodes linked to
@@ -472,7 +489,8 @@ We represent a path as a nonempty sequence of nodes, where each node is linked t
 path. We define two predicates, one that defines a valid path, and another that determines whether the given
 path is a valid one between two specific nodes in the graph:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 class Node
 {
   // a single field giving the nodes linked to
@@ -507,7 +525,8 @@ of the nodes of the graph which also forms a graph. This sub-graph must be *clos
 outside of itself. If we have such a situation, then there cannot be a valid path from a node in the sub-graph
 to a node outside this sub-graph. We will call this fact the Closed Lemma, which we state in Dafny as follows:
 
-```dafny <!-- %check-verify Lemmas.7.expect -->
+<!-- %check-verify Lemmas.7.expect -->
+```dafny
 lemma ClosedLemma(subgraph: set<Node>, root: Node, goal: Node, graph: set<Node>)
   requires closed(subgraph) && closed(graph) && subgraph <= graph
   requires root in subgraph && goal in graph - subgraph
@@ -552,7 +571,8 @@ it cannot be a valid path. We can do this with, you guessed it, another lemma. T
 prove for any given sequence, that it cannot be a valid path from `root` to `goal`.
 The disproof of a path lemma looks like:
 
-```dafny <!-- %check-verify Lemmas.8.expect -->
+<!-- %check-verify Lemmas.8.expect -->
+```dafny
 lemma DisproofLemma(p: seq<Node>, subgraph: set<Node>,
                     root: Node, goal: Node, graph: set<Node>)
   requires closed(subgraph) && closed(graph) && subgraph <= graph
@@ -591,7 +611,8 @@ The preconditions are the same as `ClosedLemma`.  To use `DisproofLemma` in `Clo
 to invoke it once for every sequence of nodes.  This can be done with Dafny's `forall` statement,
 which aggregates the effect of its body for all values of the given bound variable.
 
-```dafny <!-- %check-verify Lemmas.9.expect -->
+<!-- %check-verify Lemmas.9.expect -->
+```dafny
 lemma ClosedLemma(subgraph: set<Node>, root: Node, goal: Node, graph: set<Node>)
   requires closed(subgraph) && closed(graph) && subgraph <= graph
   requires root in subgraph && goal in graph - subgraph
@@ -645,7 +666,8 @@ element needs to be `goal`. Because `root in subgraph` and `goal !in subgraph`, 
 have `root != goal`, so the sequence must have at least two elements. To check that Dafny sees this,
 we can temporarily put preconditions on our lemma as follows:
 
-```dafny <!-- %check-verify Lemmas.10.expect -->
+<!-- %check-verify Lemmas.10.expect -->
+```dafny
 lemma DisproofLemma(p: seq<Node>, subgraph: set<Node>,
                     root: Node, goal: Node, graph: set<Node>)
   requires closed(subgraph) && closed(graph) && subgraph <= graph
@@ -696,7 +718,8 @@ which means that Dafny is able to prove the postcondition in these circumstances
 prove that the path is invalid when these conditions do not hold. We can use an `if` statement to express
 this:
 
-```dafny <!-- %no-check -->
+<!-- %no-check -->
+```dafny
 if 1 < |p| && p[0] == root && p[|p|-1] == goal {
   (further proof)
 }
@@ -718,7 +741,8 @@ counting example, Dafny can see that if the first to second node link is not val
 cannot be a path because this mirrors the definition of `path`. Thus we only have further work to do
 if the first link is valid. We can express this with another `if` statement:
 
-```dafny <!-- %no-check -->
+<!-- %no-check -->
+```dafny
 if 1 < |p| && p[0] == root && p[|p|-1] == goal {
   if p[1] in p[0].next {
     (yet further proof)
@@ -733,7 +757,8 @@ version of the same problem. We can just recursively call `DisproofLemma` to pro
 not a path. This means, per the definition of `path`, that `p` cannot be a path, and the second postcondition
 is satisfied. This can be implemented as:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 lemma DisproofLemma(p: seq<Node>, subgraph: set<Node>,
                     root: Node, goal: Node, graph: set<Node>)
   requires closed(subgraph) && closed(graph) && subgraph <= graph

--- a/latest/OnlineTutorial/Modules.md
+++ b/latest/OnlineTutorial/Modules.md
@@ -18,7 +18,8 @@ from an interface.
 A new module is declared with the `module` keyword, followed by the name of the new module, and a
 pair of curly braces (`{}`) enclosing the body of the module:
 
-```dafny <!-- %no-check -->
+<!-- %no-check -->
+```dafny
 module Mod {
   ...
 }
@@ -26,7 +27,8 @@ module Mod {
 
 A module body can consist of anything that you could put at the toplevel. This includes classes, datatypes, types, methods, functions, etc.
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 module Mod {
   class C {
     var f: int;
@@ -41,7 +43,8 @@ module Mod {
 
 You can also put a module inside another, in a nested fashion:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 module Mod {
   module Helpers {
     class C {
@@ -55,7 +58,8 @@ module Mod {
 Then you can refer to the members of the `Helpers` module within the `Mod`
 module by prefixing them with "`Helpers.`". For example:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 module Mod {
   module Helpers {
     class C {
@@ -75,7 +79,8 @@ module Mod {
 Methods and functions defined at the module level are available like classes, with just the module
 name prefixing them. They are also available in the methods and functions of the classes in the same module.
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 module Mod {
   module Helpers {
     function method addOne(n: nat): nat {
@@ -93,7 +98,8 @@ By default, definitions of functions (and predicates) are exposed outside of
 the module they are defined in. This can be controlled more precisely with
 export sets, as we will see in the following section. So adding
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 module Mod {
   module Helpers {
     function method addOne(n: nat): nat {
@@ -120,7 +126,8 @@ The simplest kind is the *concrete import*, and has the form `import A = B`. Thi
 module containing the `import` declaration; it does not create a global alias. For example, if `Helpers` was
 defined outside of `Mod`, then we could import it:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 module Helpers {
   function method addOne(n: nat): nat
   {
@@ -147,7 +154,8 @@ same time, so sometimes you have to use the `=` version to ensure the names do n
 
 By default, an `import` will give access to all declarations (and their definitions) from the imported module. To control this more precisely we can instead use `export` sets. Each `export` set may have a list of declarations from the current module, given as `provides` or `reveals`. An `export` without a name is considered the default export for that module, and is used when no set is explicitly named.
 
-```dafny  <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 module Helpers {
   export Spec provides addOne, addOne_result
   export Body reveals addOne
@@ -166,7 +174,8 @@ In this example we declare 3 export sets, the `Spec` set grants access to the `a
 
 We can now choose any of these export sets when importing `Helpers` and get different views of it.
 
-```dafny <!-- %check-verify Modules.1.expect -->
+<!-- %check-verify Modules.1.expect -->
+```dafny
 module Helpers {
   export Spec provides addOne, addOne_result
   export Body reveals addOne
@@ -210,7 +219,8 @@ module Mod3 {
 
 We may also use `export` sets to control which type definitions are available. All type declarations (i.e. `newtype`, `type`, `datatype`, etc.) can be exported as `provides` or `reveals`. In the former case, modules which `import` that type will treat it as an opaque type.
 
-```dafny  <!-- %check-resolve Modules.2.expect -->
+<!-- %check-resolve Modules.2.expect -->
+```dafny
 module Helpers {
   export provides f, T
   export Body reveals f, T
@@ -226,7 +236,8 @@ module Mod {
 
 Once an `export` has been imported that `reveals` a previously opaque type, all existing uses of it are known to be the inner type.
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 module Helpers {
   export provides f, T
   export Body reveals f, T
@@ -248,7 +259,8 @@ module Mod2 {
 
 As a convenient shorthand, the special identifier "*" can be given after `provides` or `reveals` to indicate that all declarations should be either provided or revealed.
 
-```dafny  <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 module A {
    export All reveals * // reveals T, f, g
    export Spec provides * // provides T, f, g
@@ -261,7 +273,8 @@ module A {
 
 We can also provide multiple exports at once to create an aggregate `import`.
 
-```dafny  <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 module A {
   export Justf reveals f
   export JustT reveals T
@@ -279,7 +292,8 @@ module B {
 
 An `export` set must always present a coherent view of a module: anything that appears in an exported declaration must itself be exported. Revisiting the previous example, we could not create an `export` set that `reveals` `f` without also revealing `T`, because the return type of `f` is `T`. This is for the simple reason that we would create a type constraint `0 : T` which cannot be solved if `T` is opaque. Similarly we cannot create an export set that `provides` or `reveals` `f` if we do not also at least provide `T`.
 
-```dafny  <!-- %check-resolve Modules.3.expect -->
+<!-- %check-resolve Modules.3.expect -->
+```dafny
 module Helpers {
   export provides f, T // good
   export Body reveals f, T // good
@@ -292,7 +306,8 @@ module Helpers {
 
 Since we may define modules which contain both `import` and `export` declarations, we may need to export declarations from foreign modules in order to create a consistent `export` set. Declarations from foreign modules cannot be included in an `export` directly, however the `import` that provided them can.
 
-```dafny <!-- %check-resolve Modules.4.expect -->
+<!-- %check-resolve Modules.4.expect -->
+```dafny
 module Helpers {
   export provides f, T
   type T = int
@@ -310,7 +325,8 @@ module Mod {
 
 When importing `Mod` we now also gain qualified access to what is provided in its `import A`. We may also choose to directly import these, to give them a shorter name.
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 module Helpers {
   export provides f, T
   type T = int
@@ -337,7 +353,8 @@ In this case, you can import the module as "`opened`", which causes all of its m
 `opened` keyword must immediately follow `import`, if it is present. For
 example, we could write the previous `addOne` example as:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 module Helpers {
   function method addOne(n: nat): nat
   {
@@ -357,7 +374,8 @@ definitions. This means if you define a local function called `addOne`, the func
 will no longer be available under that name. When modules are opened, the original name binding is still
 present however, so you can always use the name that was bound to get to anything that is hidden.
 
-```dafny <!-- %check-verify Modules.5.expect -->
+<!-- %check-verify Modules.5.expect -->
+```dafny
 module Helpers {
   function method addOne(n: nat): nat
   {
@@ -391,7 +409,8 @@ In that case, you can use an *abstract* module import. In Dafny, this is written
 `B` may have abstract type definitions, classes with bodyless methods, or otherwise be unsuitable to use directly. Because of the way refinement
 is defined, any refinement of `B` can be used safely. For example, if we start with:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 abstract module Interface {
   function method addSome(n: nat): nat
     ensures addSome(n) > n
@@ -407,7 +426,8 @@ abstract module Mod {
 then we can be more precise if we know that `addSome` actually adds exactly one. The following module has this behavior. Further, the postcondition is stronger,
 so this is actually a refinement of the `Interface` module.
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 abstract module Interface {
   function method addSome(n: nat): nat
     ensures addSome(n) > n
@@ -429,7 +449,8 @@ module Implementation refines Interface {
 
 We can then substitute `Implementation` for `A` in a new module, by declaring a refinement of `Mod` which defines `A` to be `Implementation`.
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 abstract module Interface {
   function method addSome(n: nat): nat
     ensures addSome(n) > n
@@ -466,14 +487,16 @@ When you refine an abstract import into a concrete one, the concrete module must
   such that each only refers to things defined <strong>before</strong> it in the source text. That doesn't mean the modules have to be given in that order. Dafny will figure out that order for you, assuming
   you haven't made any circular references. For example, this is pretty clearly meaningless:
 
-```dafny <!-- %check-resolve Modules.6.expect -->
+<!-- %check-resolve Modules.6.expect -->
+```dafny
 import A = B
 import B = A
 ```
 
 You can have import statements at the toplevel, and you can import modules defined at the same level:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 import A = B
 method m() {
   A.whatever();
@@ -489,7 +512,8 @@ then Dafny will give an error, complaining about a cyclic dependency.
 Note that when rearranging modules and imports, they have to be kept in the same containing module, which disallows some pathological module structures. Also, the
 imports and submodules are always considered to be first, even at the toplevel. This means that the following is not well formed:
 
-```dafny <!-- %check-resolve Modules.7.expect -->
+<!-- %check-resolve Modules.7.expect -->
+```dafny
 method doIt() { }
 module M {
   method m() {

--- a/latest/OnlineTutorial/Sequences.md
+++ b/latest/OnlineTutorial/Sequences.md
@@ -9,6 +9,7 @@ modified once they are created. In this sense, they are similar to strings in
 languages like Java and Python, except they can be sequences of arbitrary
 types, rather than only characters. Sequence types are written:
 
+<!-- %no-check -->
 ```dafny
 seq<int>
 ```
@@ -16,6 +17,7 @@ seq<int>
 for a sequence of integers, for example.
 For example, this function takes a sequence as a parameter:
 
+<!-- %check-verify -->
 ```dafny
 predicate sorted(s: seq<int>)
 {
@@ -33,6 +35,7 @@ manipulate them. For example, another way of expressing sorted-ness is
 recursive: if the first element is smaller than the rest, and the rest is
 sorted, then the whole array is sorted:
 
+<!-- %check-verify -->
 ```dafny
 predicate sorted2(s: seq<int>)
 {
@@ -50,6 +53,7 @@ the same order, except for the first one. This is similar to addition of
 integers in that the original values are not changed, just new ones created.
 The slice notation is:
 
+<!-- %no-check -->
 ```dafny
   s[i..j]
 ```
@@ -62,8 +66,11 @@ same half-open interval used for regular indexing.
 
 Sequences can also be constructed from their elements, using *display notation*:
 
+<!-- %check-verify -->
 ```dafny
+method m() {
   var s := [1, 2, 3];
+}
 ```
 
 Here we have a integer sequence variable in some imperative
@@ -71,6 +78,7 @@ code containing the elements 1, 2, and 3. Type inference has been used here to
 determine that the sequence is one of integers. This notation allows us to
 construct empty sequences and singleton sequences:
 
+<!-- %no-check -->
 ```dafny
   [] // the empty sequence, which can be a sequence of any type
   [true] // a singleton sequence of type seq<bool>
@@ -79,6 +87,7 @@ construct empty sequences and singleton sequences:
 Slice notation and display notation can be used to check
 properties of sequences:
 
+<!-- %check-verify -->
 ```dafny
 method m()
 {
@@ -97,6 +106,7 @@ element, as these are often used in recursive functions, such as `sorted2`
 above. In addition to being deconstructed by being accessed or sliced, sequences
 can also be concatenated, using the plus (`+`) symbol:
 
+<!-- %check-verify -->
 ```dafny
 method m()
 {
@@ -113,6 +123,7 @@ side and inclusive on the other, the element appears in the concatenation
 exactly once, as it should. Note that the concatenation operation is
 associative:
 
+<!-- %check-verify -->
 ```dafny
 method m()
 {
@@ -128,6 +139,7 @@ more information on why this is necessary).
 Sequences also support the `in` and `!in` operators, which test
 for containment within a sequence:
 
+<!-- %check-verify -->
 ```dafny
 method m()
 {
@@ -142,11 +154,12 @@ the elements of a sequence, when we don't care about the index. For example, we
 can require that a sequence only contains elements which are indices into the
 sequence:
 
+<!-- %check-verify -->
 ```dafny
 method m()
 {
-  var p := [2,3,1,0];
-  assert forall i :: i in p ==> 0 <= i < |s|;
+  var s := [2,3,1,0];
+  assert forall i :: i in s ==> 0 <= i < |s|;
 }
 ```
 
@@ -159,6 +172,7 @@ arrays using sequences. While we can't change the original sequence, we can
 create a new sequence with the same elements everywhere except for the updated
 element:
 
+<!-- %check-verify -->
 ```dafny
 method m()
 {
@@ -171,9 +185,10 @@ Of course, the index `i` has to be an index into the array. This syntax is just
 a shortcut for an operation that can be done with regular slicing and access operations.
 Can you fill in the code below that does this?
 
+<!-- %check-verify -->
 ```dafny
 function update(s: seq<int>, i: int, v: int): seq<int>
-  requires 0 <= index < |s|
+  requires 0 <= i < |s|
   ensures update(s, i, v) == s[i := v]
 {
   s[..i] + [v] + s[i+1..]
@@ -185,23 +200,25 @@ function update(s: seq<int>, i: int, v: int): seq<int>
 You can also form a sequence from the elements of an array. This is done
 using the same "slice" notation as above:
 
+<!-- %check-verify -->
 ```dafny
 method m()
 {
-  var a := new int[3]; // 3 element array of ints
+  var a := new int[][42, 43, 44]; // 3 element array of ints
   a[0], a[1], a[2] := 0, 3, -1;
   var s := a[..];
   assert s == [0, 3, -1];
 }
 ```
 
-To get just part of the array, the bounds can be given just like in a regular
+To extract just part of the array, the bounds can be given just like in a regular
 slicing operation:
 
+<!-- %check-verify -->
 ```dafny
 method m()
 {
-  var a := new int[3]; // 3 element array of ints
+  var a := new int[][42, 43, 44]; // 3 element array of ints
   a[0], a[1], a[2] := 0, 3, -1;
   assert a[1..] == [3, -1];
   assert a[..1] == [0];
@@ -212,23 +229,27 @@ method m()
 Because sequences support `in` and `!in`, this operation gives us
 an easy way to express the "element not in array" property, turning:
 
+<!-- %no-check -->
 ```dafny
 forall k :: 0 <= k < a.Length ==> elem != a[k]
 ```
 
 into:
 
+<!-- %no-check -->
 ```dafny
 elem !in a[..]
 ```
 
 Further, bounds are easily included:
+<!-- %no-check -->
 ```dafny
 forall k :: 0 <= k < i ==> elem != a[k]
 ```
 
 is the same as
 
+<!-- %no-check -->
 ```dafny
 elem !in a[..i]
 ```

--- a/latest/OnlineTutorial/Sets.md
+++ b/latest/OnlineTutorial/Sets.md
@@ -8,12 +8,14 @@ sequences, sets are immutable value types. This allows them to be used easily
 in annotations, without involving the heap, as a set cannot be modified once
 it has been created. A set has the type:
 
+<!-- %no-check -->
 ```dafny
   set<int>
 ```
 
 for a set of integers, for example. In general, sets can be of almost any type, including objects. Concrete sets can be specified by using display notation:
 
+<!-- %check-verify -->
 ```dafny
 method m()
 {
@@ -26,14 +28,21 @@ method m()
 ```
 
 The set formed by the display is the expected set, containing just
-the elements specified. Above we also see that equality is defined
+the elements specified. For the case of the empty set, the type of the
+variable `s1 above is not fully known from its initialization. However,
+later `s1` is compared to `s2`, so it must have the same type as `s2`,
+namely `set<int>`. However, in the example below, there is no such use of `s1`, 
+so the type of `s1` must be specifically stated in its declaration.
+
+Above we also see that equality is defined
 for sets. Two sets are equal if they have exactly the same elements.
 New sets can be created from existing ones using the common set operations:
 
+<!-- %check-verify -->
 ```dafny
 method m()
 {
-  var s1 := {};
+  var s1: set<int> := {};
   var s2 := {1, 2, 3};
   var s3, s4 := {1,2}, {1,4};
   assert s2 + s4 == {1,2,3,4}; // set union
@@ -49,12 +58,13 @@ operators, the set operators are always defined. In addition to set
 forming operators, there are comparison operators with their usual
 meanings:
 
+<!-- %check-verify -->
 ```dafny
 method m()
 {
   assert {1} <= {1, 2} && {1, 2} <= {1, 2}; // subset
   assert {} < {1, 2} && !({1} < {1}); // strict, or proper, subset
-  assert !({1, 2} <= {1, 4}) && !({1, 4} <= {1, 4}); // no relation
+  assert !({1, 2} <= {1, 4}) && !({1, 4} <= {1}); // not subsets
   assert {1, 2} == {1, 2} && {1, 3} != {1, 2}; // equality and non-equality
 }
 ```
@@ -62,13 +72,14 @@ method m()
 Sets, like sequences, support the `in` and `!in` operators, to
 test element membership. For example:
 
+<!-- %check-verify-warn Sets.W1.expect -->
 ```dafny
 method m()
 {
   assert 5 in {1,3,4,5};
   assert 1 in {1,3,4,5};
   assert 2 !in {1,3,4,5};
-  assert forall x :: x !in {};
+  assert forall x: int :: x !in {};
 }
 ```
 
@@ -94,6 +105,7 @@ A useful way to create sets is using a set comprehension. This defines
 a new set by including `f(x)`
 in the set for all `x` of type `T` that satisfy `p(x)`:
 
+<!-- %no-check -->
 ```dafny
   set x: T | p(x) :: f(x)
 ```
@@ -105,6 +117,7 @@ the type of the return value of `f(x)`. The values in the constructed set are th
 `x` itself acts only as a bridge between the predicate `p` and the function `f`. It
 usually has the same type as the resulting set, but it does not need to. As an example:
 
+<!-- %check-verify-warn Sets.W2.expect -->
 ```dafny
 method m()
 {
@@ -114,6 +127,7 @@ method m()
 
 If the function is the identity, then the expression can be written with a particularly nice form:
 
+<!-- %check-verify-warn Sets.W3.expect -->
 ```dafny
 method m()
 {
@@ -124,6 +138,7 @@ method m()
 To reason about general, non-identity functions in set comprehensions, Dafny may need some help.
 For example, the following is true, but Dafny cannot prove it:
 
+<!-- %check-verify Sets.1.expect -->
 ```dafny
 method m()
 {
@@ -135,6 +150,14 @@ method m()
 To help Dafny prove this assertion, you can precede it with the assertion
 `assert {0*1, 1*1, 2*1} == {0,1,2};`. This lets Dafny figure out both assertions.
 
+<!-- %check-verify -->
+```dafny
+method m()
+{
+  assert {0*1, 1*1, 2*1} == {0,1,2};  // include this assertion as a lemma to prove the next line
+  assert (set x | x in {0,1,2} :: x * 1) == {0,1,2};
+}
+```
 Without care, a set comprehension could prescribe an infinite number of elements, but a `set`
 is only allowed to have a finite number of elements. For example, if you tried writing
 `set x | x % 2 == 0` as the set of all even integers, then you would get an error.

--- a/latest/OnlineTutorial/Termination.md
+++ b/latest/OnlineTutorial/Termination.md
@@ -23,7 +23,8 @@ natural lower bound, zero, and it is usually quite easy to prove that they
 decrease. Since many loops iterate through indices, these kinds of termination
 proofs are very common. For example, we may have the following loop:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method m(n: nat)
 {
   var i := 0;
@@ -43,13 +44,15 @@ measure. Dafny sees that there is no explicit decreases annotation, so it tries
 to guess one. It sees that the loop condition is a comparison of the form `A < B`,
  for some `A` and `B`, so it makes the guess:
 
-```dafny <!-- %no-check -->
+<!-- %no-check -->
+```dafny
   decreases B - A
 ```
 
 in this case:
 
-```dafny <!-- %no-check -->
+<!-- %no-check -->
+```dafny
   decreases n - i
 ```
 
@@ -58,7 +61,8 @@ verify. Dafny is actually a little less strict than requiring the termination
 measure to be bounded by zero. Really what it requires is that the loop does
 not execute again when the termination measure is negative. So we could write:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method m()
 {
   var i, n := 0, 11;
@@ -83,7 +87,8 @@ recursion. For each function/method that is possibly recursive, it requires
 either an explicit or implicit decreases annotation on the function or method.
 Most recursive functions/methods are self-recursive:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 function fac(n: nat): nat
 {
   if n == 0 then 1 else n * fac(n-1)
@@ -95,7 +100,8 @@ functions which are recursive, they just call themselves with smaller values of
 the parameters, so the parameters decreasing is the default guess. The
 decreases annotation can be made explicit by adding:
 
-```dafny <!-- %no-check -->
+<!-- %no-check -->
+```dafny
   decreases n
 ```
 
@@ -105,7 +111,8 @@ Sometimes it is beneficial to have loops which may not
 terminate, or where a proof of termination is unknown. For example, consider
 the following method:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method hail(N: nat)
   decreases *
 {
@@ -139,7 +146,8 @@ want details.) The final kind of termination measure is a tuple of the other kin
 measures. For example, the following implementation of the Ackermann function
 uses a pair of integers to prove termination:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 function Ack(m: nat, n: nat): nat
   decreases m, n
 {
@@ -175,7 +183,8 @@ Termination applies not just to single functions/methods,
 but also to multiple mutually recursive functions/methods. For example,
 consider this pair of recursively defined parity predicates:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 predicate even(n: nat)
   ensures even(n) <==> n % 2 == 0
 {

--- a/latest/OnlineTutorial/ValueTypes.md
+++ b/latest/OnlineTutorial/ValueTypes.md
@@ -32,16 +32,18 @@ sequences, sets are immutable value types. This allows them to be used easily
 in annotations, without involving the heap, as a set cannot be modified once
 it has been created. A set has the type:
 
+<!-- %no-check -->
 ```dafny
   set<int>
 ```
 
 for a set of integers, for example. In general, sets can be of almost any type, including objects. Concrete sets can be specified by using display notation:
 
+<!-- %check-verify -->
 ```dafny
-method()
+method m()
 {
-  var s1 := {}; // the empty set
+  var s1: set<int> := {}; // the empty set
   var s2 := {1, 2, 3}; // set contains exactly 1, 2, and 3
   assert s2 == {1,1,2,3,3,3,3}; // same as before
   var s3, s4 := {1,2}, {1,4};
@@ -53,10 +55,11 @@ the elements specified. Above we also see that equality is defined
 for sets. Two sets are equal if they have exactly the same elements.
 New sets can be created from existing ones using the common set operations:
 
+<!-- %check-verify -->
 ```dafny
 method m ()
 {
-  var s1 := {};
+  var s1: set<int> := {};
   var s2 := {1, 2, 3};
   var s3, s4 := {1,2}, {1,4};
   assert s2 + s4 == {1,2,3,4}; // set union
@@ -73,12 +76,13 @@ operators, the set operators are always defined. In addition to set
 forming operators, there are comparison operators with their usual
 meanings:
 
+<!-- %check-verify -->
 ```dafny
 method m()
 {
   assert {1} <= {1, 2} && {1, 2} <= {1, 2}; // subset
   assert {} < {1, 2} && !({1} < {1}); // strict, or proper, subset
-  assert !({1, 2} <= {1, 4}) && !({1, 4} <= {1, 4}); // no relation
+  assert !({1, 2} <= {1, 4}) && !({1, 4} <= {1}); // not subsets
   assert {1, 2} == {1, 2} && {1, 3} != {1, 2}; // equality and non-equality
 }
 ```
@@ -86,13 +90,14 @@ method m()
 Sets, like sequences, support the `in` and `!in` operators, to
 test element membership. For example:
 
+<!-- %check-verify-warn Sets.W1.expect -->
 ```dafny
 method m()
 {
   assert 5 in {1,3,4,5};
   assert 1 in {1,3,4,5};
   assert 2 !in {1,3,4,5};
-  assert forall x :: x !in {};
+  assert forall x: int :: x !in {};
 }
 ```
 
@@ -118,6 +123,7 @@ only if `s` has no elements.)
 A useful way to create sets is using a set comprehension. This defines a new set by including `f(x)`
 in the set for all `x` of type `T` that satisfy `p(x)`:
 
+<!-- %no-check -->
 ```dafny
   set x: T | p(x) :: f(x)
 ```
@@ -129,15 +135,17 @@ the type of the return value of `f(x)`. The values in the constructed set are th
 `x` itself acts only as a bridge between the predicate `p` and the function `f`. It
 usually has the same type as the resulting set, but it does not need to. As an example:
 
+<!-- %check-verify-warn Sets.W2.expect -->
 ```dafny
 method m()
 {
-  assert (set x | x in {0,1,2} :: x * 1) == {0,1,2};
+  assert (set x | x in {0,1,2} :: x + 0) == {0,1,2};
 }
 ```
 
 If the function is the identity, then the expression can be written with a particularly nice form:
 
+<!-- %check-verify-warn Sets.W3.expect -->
 ```dafny
 method m()
 {
@@ -148,10 +156,12 @@ method m()
 General, non-identity functions in set comprehensions confuse Dafny easily. For example,
 the following is true, but Dafny cannot prove it:
 
+<!-- %check-verify  Sets.1.expect -->
 ```dafny
 method m()
 {
-  assert (set x | x in {0,1,2} :: x + 1) == {1,2,3};
+  // assert {0*1, 1*1, 2*1} == {0,1,2};  // include this assertion as a lemma to prove the next line
+  assert (set x | x in {0,1,2} :: x * 1) == {0,1,2};
 }
 ```
 
@@ -163,7 +173,6 @@ variable to be in an existing set also works, as in `x in {0,1,2}` from above. T
 only when the inclusion part is conjuncted (`&&`'ed) with the rest of the predicate, as it
 needs to limit the possible values to consider.
 
-
 ## Sequences
 
 Sequences are a built-in Dafny type representing an ordered
@@ -173,6 +182,7 @@ modified once they are created. In this sense, they are similar to strings in
 languages like Java and Python, except they can be sequences of arbitrary
 types, rather than only characters. Sequence types are written:
 
+<!-- %no-check -->
 ```dafny
   seq<int>
 ```
@@ -180,6 +190,7 @@ types, rather than only characters. Sequence types are written:
 for a sequence of integers, for example. 
 For example, this function takes a sequence as a parameter:
 
+<!-- %check-verify -->
 ```dafny
 predicate sorted(s: seq<int>)
 {
@@ -197,6 +208,7 @@ manipulate them. For example, another way of expressing sorted-ness is
 recursive: if the first element is smaller than the rest, and the rest is
 sorted, then the whole array is sorted:
 
+<!-- %check-verify -->
 ```dafny
 predicate sorted2(s: seq<int>)
 {
@@ -214,6 +226,7 @@ the same order, except for the first one. This is similar to addition of
 integers in that the original values are not changed, just new ones created.
 The slice notation is:
 
+<!-- %no-check -->
 ```dafny
   s[i..j]
 ```
@@ -226,8 +239,11 @@ same half-open interval used for regular indexing.
 
 Sequences can also be constructed from their elements, using *display notation*:
 
+<!-- %check-verify -->
 ```dafny
+method m() {
   var s := [1, 2, 3];
+}
 ```
 
 Here we have a integer sequence variable in some imperative
@@ -235,6 +251,7 @@ code containing the elements 1, 2, and 3. Type inference has been used here to
 determine that the sequence is one of integers. This notation allows us to
 construct empty sequences and singleton sequences:
 
+<!-- %no-check -->
 ```dafny
   [] // the empty sequence, which can be a sequence of any type
   [true] // a singleton sequence of type seq<bool>
@@ -243,6 +260,7 @@ construct empty sequences and singleton sequences:
 Slice notation and display notation can be used to check
 properties of sequences:
 
+<!-- %check-verify -->
 ```dafny
 method m()
 {
@@ -261,6 +279,7 @@ element, as these are often used in recursive functions, such as `sorted2`
 above. In addition to being deconstructed by being accessed or sliced, sequences
 can also be concatenated, using the plus (`+`) symbol:
 
+<!-- %check-verify -->
 ```dafny
 method m()
 {
@@ -277,6 +296,7 @@ side and inclusive on the other, the `i`th element appears in the concatenation
 exactly once, as it should. Note that the concatenation operation is
 associative:
 
+<!-- %check-verify -->
 ```dafny
 method m()
 {
@@ -292,6 +312,7 @@ more information on why this is necessary).
 Sequences also support the `in` and `!in` operators, which test
 for containment within a sequence:
 
+<!-- %check-verify -->
 ```dafny
 method m()
 {
@@ -306,11 +327,12 @@ the elements of a sequence, when we don't care about the index. For example, we
 can require that a sequence only contains elements which are indices into the
 sequence:
 
+<!-- %check-verify -->
 ```dafny
 method m()
 {
-  var p := [2,3,1,0];
-  assert forall i :: i in p ==> 0 <= i < |s|;
+  var s := [2,3,1,0];
+  assert forall i :: i in s ==> 0 <= i < |s|;
 }
 ```
 
@@ -323,6 +345,7 @@ arrays using sequences. While we can't change the original sequence, we can
 create a new sequence with the same elements everywhere except for the updated
 element:
 
+<!-- %check-verify -->
 ```dafny
 method m()
 {
@@ -335,9 +358,10 @@ Of course, the index `i` has to be an index into the array. This syntax is just
 a shortcut for an operation that can be done with regular slicing and access operations.
 Can you fill in the code below that does this?
 
+<!-- %check-verify -->
 ```dafny
 function update(s: seq<int>, i: int, v: int): seq<int>
-  requires 0 <= index < |s|
+  requires 0 <= i < |s|
   ensures update(s, i, v) == s[i := v]
 {
   s[..i] + [v] + s[i+1..]
@@ -349,10 +373,11 @@ function update(s: seq<int>, i: int, v: int): seq<int>
 You can also form a sequence from the elements of an array. This is done
 using the same "slice" notation as above:
 
+<!-- %check-verify -->
 ```dafny
 method m()
 {
-  var a := new int[3]; // 3 element array of ints
+  var a := new int[][42,43,44]; // 3 element array of ints
   a[0], a[1], a[2] := 0, 3, -1;
   var s := a[..];
   assert s == [0, 3, -1];
@@ -362,10 +387,11 @@ method m()
 To extract just part of the array, the bounds can be given just like in a regular
 slicing operation:
 
+<!-- %check-verify -->
 ```dafny
 method m()
 {
-  var a := new int[3]; // 3 element array of ints
+  var a := new int[][42,43,44]; // 3 element array of ints
   a[0], a[1], a[2] := 0, 3, -1;
   assert a[1..] == [3, -1];
   assert a[..1] == [0];
@@ -376,24 +402,28 @@ method m()
 Because sequences support `in` and `!in`, this operation gives us
 an easy way to express the "element not in array" property, turning:
 
+<!-- %no-check -->
 ```dafny
 forall k :: 0 <= k < a.Length ==> elem != a[k]
 ```
 
 into:
 
+<!-- %no-check -->
 ```dafny
 elem !in a[..]
 ```
 
 Further, bounds are easily included:
 
+<!-- %no-check -->
 ```dafny
 forall k :: 0 <= k < i ==> elem != a[k]
 ```
 
 is the same as
 
+<!-- %no-check -->
 ```dafny
 elem !in a[..i]
 ```
@@ -405,12 +435,14 @@ many copies of each element they have. This makes them particularly useful for s
 the set of elements in an array, for example, where the number of copies of each element is the same.
 The multiset type is almost the same as sets:
 
+<!-- %no-check -->
 ```dafny
   multiset<int>
 ```
 
 Similarly, to give a multiset literal, you write curly braces, except preceeded by the `multiset` keyword:
 
+<!-- %no-check -->
 ```dafny
   multiset{3,5,7,3}
 ```
@@ -427,6 +459,7 @@ test whether some element is in a multiset (in means that it has at least one me
 union would have a total of three 3's. The multiset difference (`-`) works similarly, in that the duplicity of the elements
 (i.e. how many of each element are in the multiset) matters. So the following:
 
+<!-- %check-verify -->
 ```dafny
 method test()
 {
@@ -442,6 +475,7 @@ Also, two multisets are equal if they have exactly the same count of each elemen
 
 Finally, multisets can be created from both sequences and sets by using multiset with parentheses:
 
+<!-- %check-verify -->
 ```dafny
 method test()
 {
@@ -464,6 +498,7 @@ Maps in Dafny represent *associative arrays*. Unlike the other types so far, the
 the *key* type, and the *value* type.
 Values can be retrieved, or looked up, based on the key. A map type is written:
 
+<!-- %no-check -->
 ```dafny
   map<U, V>
 ```
@@ -473,6 +508,7 @@ to integers as `map<int, int>`. A literal of this type might be `map[4 := 5, 5 :
 associates 4 with 5 and 5 with 6. You can access the value for a given key with `m[key]`, if `m` is a
 map and `key` is a key. So we could write:
 
+<!-- %check-verify -->
 ```dafny
 method test() {
   var m := map[4 := 5, 5 := 6];
@@ -499,6 +535,7 @@ map equal keys to equal values. Also, the domain of a map must always be finite.
 
 Like sets, maps have a map comprehension. The syntax is almost the same as for sets:
 
+<!-- %no-check -->
 ```dafny
 map i: T | p(i) :: f(i)
 ```
@@ -506,6 +543,7 @@ map i: T | p(i) :: f(i)
 The difference is that `i` is the key, and it is mapped to `f(i)`. `p(i)` is used to determine what the domain
 of the new map is. So:
 
+<!-- %check-verify -->
 ```dafny
 method test() {
   var m := map i | 0 <= i < 10 :: 2*i;
@@ -515,6 +553,7 @@ method test() {
 is a map which takes the numbers 0-9 to their doubles. This is also how you can remove a key from a map. For example, this expression
 removes the key 3 from an `int` to `int` map `m`:
 
+<!-- %check-verify -->
 ```dafny
 method test() {
   var m := map[3 := 5, 4 := 6, 1 := 4];

--- a/latest/OnlineTutorial/guide.md
+++ b/latest/OnlineTutorial/guide.md
@@ -18,7 +18,8 @@ This is often easier than writing the code, because annotations are shorter and
 more direct. For example, the following fragment of annotation in Dafny says
 that every element of the array is strictly positive:
 
-```dafny <!-- %no-check -->
+<!-- %no-check -->
+```dafny
 forall k: int :: 0 <= k < a.Length ==> 0 < a[k]
 ```
 
@@ -47,7 +48,8 @@ might be called procedures, or functions, but in Dafny the term "function" is
 reserved for a different concept that we will cover later. A method is declared
 in the following way:
 
-```dafny <!-- %check-verify guide.1.expect -->
+<!-- %check-verify guide.1.expect -->
+```dafny
 method Abs(x: int) returns (y: int)
 {
   ...
@@ -61,7 +63,8 @@ are required for each parameter and return value, and follow each name after a
 colon (`:`). Also, the return values are named, and there
 can be multiple return values, as in this code:
 
-```dafny <!-- %check-verify guide.2.expect -->
+<!-- %check-verify guide.2.expect -->
+```dafny
 method MultipleReturns(x: int, y: int) returns (more: int, less: int)
 {
   ...
@@ -76,7 +79,8 @@ assignments, `if` statements, loops, other method calls, `return` statements, et
 For example, the `MultipleReturns` method may be
 implemented as:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method MultipleReturns(x: int, y: int) returns (more: int, less: int)
 {
   more := x + y;
@@ -99,7 +103,8 @@ parameters are used), or they can take a list of values to return. There are
 also compound statements, such as `if` statements. `if` statements do not require
 parentheses around the boolean condition, and act as one would expect:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method Abs(x: int) returns (y: int)
 {
   if x < 0 {
@@ -144,7 +149,8 @@ condition and most specifications, a postcondition is always a boolean
 expression: something that can be *true* or *false*. In
 the case of the `Abs` method, a reasonable postcondition is the following:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method Abs(x: int) returns (y: int)
   ensures 0 <= y
 {
@@ -172,7 +178,8 @@ latter is basically the same as the former, but it separates distinct
 properties. For example, the return value names from the `MultipleReturns`
 method might lead one to guess the following postconditions:
 
-```dafny <!-- %check-verify guide.3.expect -->
+<!-- %check-verify guide.3.expect -->
+```dafny
 method MultipleReturns(x: int, y: int) returns (more: int, less: int)
   ensures less < x
   ensures x < more
@@ -184,7 +191,8 @@ method MultipleReturns(x: int, y: int) returns (more: int, less: int)
 
 The postcondition can also be written:
 
-```dafny <!-- %check-verify guide.4.expect -->
+<!-- %check-verify guide.4.expect -->
+```dafny
 method MultipleReturns(x: int, y: int) returns (more: int, less: int)
   ensures less < x && x < more
 {
@@ -195,7 +203,8 @@ method MultipleReturns(x: int, y: int) returns (more: int, less: int)
 
 or even:
 
-```dafny <!-- %check-verify guide.5.expect -->
+<!-- %check-verify guide.5.expect -->
+```dafny
 method MultipleReturns(x: int, y: int) returns (more: int, less: int)
   ensures less < x < more
 {
@@ -243,7 +252,8 @@ Preconditions have their own keyword, `requires`.
 We can give the necessary precondition to `MultipleReturns`
 as below:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method MultipleReturns(x: int, y: int) returns (more: int, less: int)
   requires 0 < y
   ensures less < x < more
@@ -268,7 +278,8 @@ is correct.
   their maximum. Add appropriate annotations and make sure your code
   verifies.*
 
-```dafny <!-- %check-verify guide.6.expect -->
+<!-- %check-verify guide.6.expect -->
+```dafny
 method Max(a: int, b: int) returns (c: int)
   // What postcondition should go here, so that the function operates as expected?
   // Hint: there are many ways to write this.
@@ -294,7 +305,8 @@ statements. An assertion says that a particular
 expression always holds when control reaches that part of the code. For
 example, the following is a trivial use of an assertion inside a dummy method:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method Testing()
 {
   assert 2 < 3;
@@ -319,7 +331,8 @@ declarations. Unlike method parameters, where types are required, Dafny can
 infer the types of local variables in almost all situations. This is an example
 of an initialized, explicitly typed variable declaration:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method m()
 {
   var x: int := 5;
@@ -328,7 +341,8 @@ method m()
 
 The type annotation can be dropped in this case:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method m()
 {
   var x := 5;
@@ -337,7 +351,8 @@ method m()
 
 Multiple variables can be declared at once:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method m()
 {
   var x, y, z: bool := 1, 2, true;
@@ -353,7 +368,8 @@ method. We cannot put `Abs` inside a specification directly, as the method could
 change memory state, among other problems. So we capture the return value of a
 call to `Abs` as follows:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method Abs(x: int) returns (y: int)
   ensures 0 <= y
 {
@@ -384,7 +400,8 @@ non-negative after the call to `Abs`.
   *Write a test method that calls your `Max` method from Exercise 0
   and then asserts something about the result.*
 
-```dafny <!-- %check-resolve -->
+<!-- %check-resolve -->
+```dafny
 method Max(a: int, b:int) returns (c: int)
   // Use your code from Exercise 0
 method Testing() {
@@ -398,7 +415,8 @@ particular, for non-negative `x`, `Abs(x) == x`. Specifically, in the
 above program, the value of `v` is 3. If we try adding an assertion (or
 changing the existing one) to say:
 
-```dafny <!-- %check-verify guide.7.expect -->
+<!-- %check-verify guide.7.expect -->
+```dafny
 method Abs(x: int) returns (y: int)
   ensures 0 <= y
 {
@@ -437,7 +455,8 @@ return values) as fixing the behavior of the method. Everywhere the method is
 used, we assume that it is any one of the conceivable method(s) that satisfies the pre- and
 postconditions. In the `Abs` case, we might have written:
 
-```dafny <!-- %check-verify guide.8.expect -->
+<!-- %check-verify guide.8.expect -->
+```dafny
 method Abs(x: int) returns (y: int)
   ensures 0 <= y
 {
@@ -455,7 +474,8 @@ method Testing()
 This method satisfies the postconditions, but clearly the
 program fragment:
 
-```dafny <!-- %check-verify guide.9.expect -->
+<!-- %check-verify guide.9.expect -->
+```dafny
 method Abs(x: int) returns (y: int)
   ensures 0 <= y
 {
@@ -476,7 +496,8 @@ constant, for example. We need stronger postconditions to eliminate these
 other possibilities, and "fix" the method down to exactly the one we want. We
 can partially do this with the following:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method Abs(x: int) returns (y: int)
   ensures 0 <= y
   ensures 0 <= x ==> y == x
@@ -506,7 +527,8 @@ negative is that the result, `y`, is positive. But this
 is still not enough to fix the method, so we must add another postcondition,
 to make the following complete annotation covering all cases:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method Abs(x: int) returns (y: int)
   ensures 0 <= y
   ensures 0 <= x ==> y == x
@@ -525,7 +547,8 @@ actually computes the absolute value of `x`. These postconditions are
 not the only way to express this property. For example, this is a different,
 and somewhat shorter, way of saying the same thing:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method Abs(x: int) returns (y: int)
   ensures 0 <= y && (y == x || y == -x)
 {
@@ -551,7 +574,8 @@ of doing this: functions.
   negative values. Simplify the body of `Abs` into just one return
   statement and make sure the method still verifies.*
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method Abs(x: int) returns (y: int)
   // Add a precondition here.
   ensures 0 <= y
@@ -574,7 +598,8 @@ method Abs(x: int) returns (y: int)
   through? What precondition do you need if the body is `y := x + 1`?
   What does that precondition say about when you can call the method?*
 
-```dafny <!-- %check-verify guide.10.expect -->
+<!-- %check-verify guide.10.expect -->
+```dafny
 method Abs(x: int) returns (y: int)
   // Add a precondition here so that the method verifies.
   // Don't change the postconditions.
@@ -597,7 +622,8 @@ method Abs2(x: int) returns (y: int)
 
 ## Functions
 
-```dafny <!-- %no-check -->
+<!-- %no-check -->
+```dafny
 function abs(x: int): int
 {
   ...
@@ -612,7 +638,8 @@ correct type. Here our body must be an integer expression. In order to
 implement the absolute value function, we need to use an *`if` expression*. An `if`
 expression is like the ternary operator in other languages.
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 function abs(x: int): int
 {
   if x < 0 then -x else x
@@ -625,7 +652,8 @@ bother with functions, if they are so limited compared to methods. The power of
 functions comes from the fact that they can be *used directly in specifications*.
 So we can write:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 function abs(x: int): int
 {
   if x < 0 then -x else x
@@ -650,7 +678,8 @@ actually `3`.
   integer parameters. Write a test method using an `assert` that
   checks that your function is correct.*
 
-```dafny <!-- %check-resolve -->
+<!-- %check-resolve -->
+```dafny
 function max(a: int, b: int): int
 {
   0 // Fill in an expression here.
@@ -663,7 +692,8 @@ method Testing() {
 One caveat of functions is that not only can they appear in
 annotations, they can only appear in annotations. One cannot write:
 
-```dafny <!-- %no-check -->
+<!-- %no-check -->
+```dafny
   var v := abs(3);
 ```
 
@@ -680,7 +710,8 @@ reference for details).
   the variable. Dafny will reject this program because you are calling
   `max` from real code. Fix this problem using a `function method`.*
 
-```dafny <!-- %check-resolve -->
+<!-- %check-resolve -->
+```dafny
 function max(a: int, b: int): int
 {
   0 // Use your code from Exercise 4
@@ -698,7 +729,8 @@ method Testing() returns (r: int) {
   this, you will realize there is not much point in having a method
   that does exactly the same thing as a function method.)*
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 function abs(x: int): int
 {
   if x < 0 then -x else x
@@ -718,7 +750,8 @@ method Abs(x: int) returns (y: int)
 Unlike methods, functions can appear in expressions. Thus we
 can do something like implement the mathematical Fibonacci function:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 function fib(n: nat): nat
 {
   if n == 0 then 0
@@ -739,7 +772,8 @@ the guarantee of correctness and the performance we want.
 
 We can start by defining a method like the following:
 
-```dafny <!-- %check-verify guide.11.expect -->
+<!-- %check-verify guide.11.expect -->
+```dafny
 function fib(n: nat): nat
 {
   if n == 0 then 0
@@ -759,7 +793,8 @@ Fibonacci number. The basic idea is to keep a counter and repeatedly calculate a
 of Fibonacci numbers until the desired number is reached. To do this, we need a loop. In Dafny, this is done
 via a *`while` loop*. A while loop looks like the following:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method m(n: nat)
 {
   var i := 0;
@@ -791,7 +826,8 @@ expressions we have seen. For example, we see in the above loop that if `i`
 starts off positive, then it stays positive. So we can add the invariant, using
 its own keyword, to the loop:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method m(n: nat)
 {
   var i := 0;
@@ -819,7 +855,8 @@ we exit the loop, we will have that `i == n`, because `i` will stop being
 incremented when it reaches `n`. We can use our assertion trick to check to see if Dafny
 sees this fact as well:
 
-```dafny <!-- %check-verify guide.12.expect -->
+<!-- %check-verify guide.12.expect -->
+```dafny
 method m(n: nat)
 {
   var i: int := 0;
@@ -842,7 +879,8 @@ Somehow we need to eliminate the possibility of `i`
 exceeding `n`. One first guess for solving this problem
 might be the following:
 
-```dafny <!-- %check-verify guide.13.expect -->
+<!-- %check-verify guide.13.expect -->
+```dafny
 method m(n: nat)
 {
   var i: int := 0;
@@ -863,7 +901,8 @@ guard holds, in the last iteration `i` goes from `n - 1` to `n`, but does not in
 further, as the loop exits. Thus, we have only omitted exactly one case from
 our invariant, and repairing it is relatively easy:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method m(n: nat)
 {
   var i: int := 0;
@@ -886,7 +925,8 @@ has executed.
   *Change the loop invariant to `0 <= i <= n+2`. Does the loop still
   verify? Does the assertion `i == n` after the loop still verify?*
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method m(n: nat)
 {
   var i: int := 0;
@@ -905,7 +945,8 @@ method m(n: nat)
   `i < n` to `i != n`. Do the loop and the assertion after the loop
   still verify? Why or why not?*
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method m(n: nat)
 {
   var i: int := 0;
@@ -936,7 +977,8 @@ reach another number, often an argument or the length of an array or sequence.
 So we have that the variable `b`, which is conveniently
 our out parameter, will be the current Fibonacci number:
 
-```dafny <!-- %no-check -->
+<!-- %no-check -->
+```dafny
   invariant b == fib(i)
 ```
 
@@ -946,7 +988,8 @@ number. So we want a way of tracking the previous Fibonacci number, which we
 will call `a`. Another invariant will express that
 number's relation to the loop counter. The invariants are:
 
-```dafny <!-- %no-check -->
+<!-- %no-check -->
+```dafny
   invariant a == fib(i - 1)
 ```
 
@@ -954,7 +997,8 @@ At each step of the loop, the two values are summed to get
 the next leading number, while the trailing number is the old leading number.
 Using a parallel assignment, we can write a loop that performs this operation:
 
-```dafny <!-- %check-verify guide.14.expect -->
+<!-- %check-verify guide.14.expect -->
+```dafny
 function fib(n: nat): nat
 {
   if n == 0 then 0
@@ -993,7 +1037,8 @@ the loop. The only problem is when `n` is zero. This can
 be eliminated as a special case, by testing for this condition at the beginning
 of the loop. The completed Fibonacci method becomes:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 function fib(n: nat): nat
 {
   if n == 0 then 0
@@ -1030,7 +1075,8 @@ and `b == fib(i)`, which together imply the postcondition, `b == fib(n)`.
   variable `c` that succeeds `b`. Verify your program is correct
   according to the mathematical definition of Fibonacci.*
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 function fib(n: nat): nat
 {
   if n == 0 then 0
@@ -1064,7 +1110,8 @@ method ComputeFib(n: nat) returns (b: nat)
   `0`.  Verify this new program by adjusting the loop invariants to
   match the new behavior.*
 
-```dafny <!-- %check-verify guide.15.expect -->
+<!-- %check-verify guide.15.expect -->
+```dafny
 function fib(n: nat): nat
 {
   if n == 0 then 0
@@ -1117,7 +1164,8 @@ details.) In the case of integers, the bound is assumed to be zero. For
 example, the following is a proper use of `decreases` on a loop (with its own
 keyword, of course):
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method m ()
 {
   var i := 20;
@@ -1137,7 +1185,8 @@ which tend to count up instead of down. In this case, what decreases is not the
 counter itself, but rather the distance between the counter and the upper
 bound. A simple trick for dealing with this situation is given below:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method m()
 {
   var i, n := 0, 20;
@@ -1168,7 +1217,8 @@ each other, and neither is fixed.
   and delete the invariant annotation. Does the program verify? What
   happened?*
 
-```dafny <!-- %check-verify guide.16.expect -->
+<!-- %check-verify guide.16.expect -->
+```dafny
 method m()
 {
   var i, n := 0, 20;
@@ -1187,7 +1237,8 @@ original caller. When Dafny is not able to guess the termination condition, an
 explicit decreases clause can be given along with pre- and postconditions, as
 in the unnecessary annotation for the fib function:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 function fib(n: nat): nat
   decreases n
 {
@@ -1235,7 +1286,8 @@ search, with a different correctness condition for each. If the algorithm
 returns an index (i.e. non-negative integer), then the key should be present at
 that index. This might be expressed as follows:
 
-```dafny <!-- %check-resolve -->
+<!-- %check-resolve -->
+```dafny
 method Find(a: array<int>, key: int) returns (index: int)
   ensures 0 <= index ==> index < a.Length && a[index] == key
 {
@@ -1271,7 +1323,8 @@ name suggests, this expression is true if some property holds for all elements
 of some set. For now, we will consider the set of integers. An example
 universal quantifier, wrapped in an assertion, is given below:
 
-```dafny <!-- %check-verify-warn guide.17.expect -->
+<!-- %check-verify-warn guide.17.expect -->
+```dafny
 method m()
 {
   assert forall k :: k < k + 1;
@@ -1293,7 +1346,8 @@ used to quantify over all elements in an array or data structure. We do this
 for arrays by using the implication operator to make the quantified property
 trivially true for values which are not indices:
 
-```dafny <!-- %no-check -->
+<!-- %no-check -->
+```dafny
   assert forall k :: 0 <= k < a.Length ==> ...a[k]...;
 ```
 
@@ -1306,13 +1360,15 @@ set of integers it must consider to only those that are indices into the array.
 With a quantifier, saying the key is not in the array is
 straightforward:
 
-```dafny <!-- %no-check -->
+<!-- %no-check -->
+```dafny
   forall k :: 0 <= k < a.Length ==> a[k] != key
 ```
 
 Thus our method postconditions become:
 
-```dafny <!-- %check-resolve -->
+<!-- %check-resolve -->
+```dafny
 method Find(a: array<int>, key: int) returns (index: int)
   ensures 0 <= index ==> index < a.Length && a[index] == key
   ensures index < 0 ==> forall k :: 0 <= k < a.Length ==> a[k] != key
@@ -1326,7 +1382,8 @@ Note that because `a` has type `array<int>`, it is implicitly non-null.
 We can fill in the body of this method in a number of ways,
 but perhaps the easiest is a linear search, implemented below:
 
-```dafny <!-- %check-verify guide.18.expect -->
+<!-- %check-verify guide.18.expect -->
+```dafny
 method Find(a: array<int>, key: int) returns (index: int)
   ensures 0 <= index ==> index < a.Length && a[index] == key
   ensures index < 0 ==> forall k :: 0 <= k < a.Length ==> a[k] != key
@@ -1349,7 +1406,8 @@ we have to write an invariant that says that everything before the current
 index has already been looked at (and are not the key). Just like the
 postcondition, we can use a quantifier to express this property:
 
-```dafny <!-- %check-verify guide.19.expect -->
+<!-- %check-verify guide.19.expect -->
+```dafny
 method Find(a: array<int>, key: int) returns (index: int)
   ensures 0 <= index ==> index < a.Length && a[index] == key
   ensures index < 0 ==> forall k :: 0 <= k < a.Length ==> a[k] != key
@@ -1387,7 +1445,8 @@ is one past the end of a growing range is a common pattern when working with
 arrays, where it is often used to build a property up one element at a time.
 The complete method is given below:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 method Find(a: array<int>, key: int) returns (index: int)
   ensures 0 <= index ==> index < a.Length && a[index] == key
   ensures index < 0 ==> forall k :: 0 <= k < a.Length ==> a[k] != key
@@ -1411,7 +1470,8 @@ method Find(a: array<int>, key: int) returns (index: int)
   postconditions that state the intent of the method, and annotate its
   body with loop invariant to verify it.*
 
-```dafny <!-- %check-resolve -->
+<!-- %check-resolve -->
+```dafny
 method FindMax(a: array<int>) returns (i: int)
   // Annotate this method with pre- and postconditions
   // that ensure it behaves as described.
@@ -1444,7 +1504,8 @@ predicate, but the easiest is to use a quantifier over the indices of the
 array. We can write a quantifier that expresses the property, "if `x` is before
 `y` in the array, then `x <= y`," as a quantifier over two bound variables:
 
-```dafny <!-- %no-check -->
+<!-- %no-check -->
+```dafny
   forall j, k :: 0 <= j < k < a.Length ==> a[j] <= a[k]
 ```
 
@@ -1456,7 +1517,8 @@ says that they are ordered properly with respect to one another. Quantifiers are
 a type of boolean valued expression in Dafny, so we can write the sorted predicate
 as:
 
-```dafny <!-- %check-verify guide.20.expect -->
+<!-- %check-verify guide.20.expect -->
+```dafny
 predicate sorted(a: array<int>)
 {
   forall j, k :: 0 <= j < k < a.Length ==> a[j] <= a[k]
@@ -1484,7 +1546,8 @@ sorted. While we might be able to give invariants to preserve it in this case,
 it gets even more complex when manipulating data structures. In this case,
 framing is essential to making the verification process feasible.
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 predicate sorted(a: array<int>)
   reads a
 {
@@ -1533,7 +1596,8 @@ distinction between the reference itself and the value it points to.)
   true exactly when the array is sorted and all its elements are
   distinct.*
 
-```dafny <!-- %check-resolve -->
+<!-- %check-resolve -->
+```dafny
 predicate sorted(a: array<int>)
   reads a
 {
@@ -1546,7 +1610,8 @@ predicate sorted(a: array<int>)
   null (using a nullable array type) but
   returns false if it is.*
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 predicate sorted(a: array<int>) // Change the type
   reads a
 {
@@ -1560,7 +1625,8 @@ predicate sorted(a: array<int>) // Change the type
 
 Predicates are usually used to make other annotations clearer:
 
-```dafny <!-- %check-resolve -->
+<!-- %check-resolve -->
+```dafny
 predicate sorted(a: array<int>)
   reads a
 {
@@ -1581,7 +1647,8 @@ is sorted. Because Dafny can unwrap functions, inside the body of the method it
 knows this too. We can then use that property to prove the correctness of the
 search. The method body is given below:
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 predicate sorted(a: array<int>)
   reads a
 {
@@ -1630,7 +1697,8 @@ when `low == high`, the loop exits. But this means that
 no elements are left in the search range, so the key was not found. This can be
 deduced from the loop invariant:
 
-```dafny <!-- %no-check -->
+<!-- %no-check -->
+```dafny
   invariant forall i ::
     0 <= i < a.Length && !(low <= i < high) ==> a[i] != value
 ```
@@ -1650,7 +1718,8 @@ ourselves.
   to `mid` or to set `high` to `mid - 1`. In each case, what goes
   wrong?*
 
-```dafny <!-- %check-verify -->
+<!-- %check-verify -->
+```dafny
 predicate sorted(a: array<int>)
   reads a
 {


### PR DESCRIPTION
Changing
\`\`\`dafny \<!-- %check-resolve -->
to 
\<!-- %check-resolve -->
\`\`\`dafny
everywhere because the former renders incorrectly.

This is just copying over changes from the development repo, but between versions.